### PR TITLE
Update example to use correct async function syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Because it supports FSA actions, you can use redux-promise in combination with [
 This works just like in Flummox:
 
 ```js
-createAction('FETCH_THING', async id => {
+createAction('FETCH_THING', async function(id) {
   const result = await somePromise;
   return result.someValue;
 });


### PR DESCRIPTION
Async arrow functions are not valid
