### PR TITLE
Update middleware link in README to Redux docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ redux-promise
 [![build status](https://img.shields.io/travis/acdlite/redux-promise/master.svg?style=flat-square)](https://travis-ci.org/acdlite/redux-promise)
 [![npm version](https://img.shields.io/npm/v/redux-promise.svg?style=flat-square)](https://www.npmjs.com/package/redux-promise)
 
-[FSA](https://github.com/acdlite/flux-standard-action)-compliant promise [middleware](https://github.com/gaearon/redux/blob/master/docs/middleware.md) for Redux.
+[FSA](https://github.com/acdlite/flux-standard-action)-compliant promise [middleware](http://rackt.github.io/redux/docs/advanced/Middleware.html) for Redux.
 
 ```js
 npm install --save redux-promise


### PR DESCRIPTION
Points to here http://rackt.github.io/redux/docs/advanced/Middleware.html
